### PR TITLE
Ignore NaN errors, code blocks, and numbers in strings

### DIFF
--- a/test.html
+++ b/test.html
@@ -48,6 +48,7 @@
         <h3>Height in text</h3>
         <p>My aunt is between 5'11" and 6'3" tall </p>
         <p>My uncle is also 6ft 3in tall</p>
+        <p>At 7', my dad is the tallest person I know</p>
         <p>This is some text with a 'string 6'</p>
         <p>This is some text with a 'much longer string that also includes 6'</p>
         <p>This is some text that shouldn't be ignored 6'</p>

--- a/test.html
+++ b/test.html
@@ -31,6 +31,28 @@
         <h3>Speed</h3>
         <p>100 mph</p>
 
+        <h3>Codeblock</h3>
+        <code>
+            func foo() {
+                let x = '10'
+                return '6'
+            }
+        </code>
+        <pre>
+            func bar() {
+                let y = '6'
+                return '7'
+            }
+        </pre>
+
+        <h3>Height in text</h3>
+        <p>My aunt is between 5'11" and 6'3" tall </p>
+        <p>My uncle is also 6ft 3in tall</p>
+        <p>This is some text with a 'string 6'</p>
+        <p>This is some text with a 'much longer string that also includes 6'</p>
+        <p>This is some text that shouldn't be ignored 6'</p>
+
+
         <script src="units.safariextension/units.js"></script>
     </body>
 </html>

--- a/units.safariextension/Info.plist
+++ b/units.safariextension/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>Chrome</key>
 	<dict/>
 	<key>Content</key>

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -32,7 +32,7 @@ function convertFeetToSI(match, feet, inches, p3, offset, str){
     }
 }
 
-var replacements = [{
+let unitsExt_Replacements = [{
     /* Change heights in format 6'5" to metric units */
     pattern: /(\d+)'(\d*)("|''|)/g,
     func: convertFeetToSI
@@ -81,7 +81,7 @@ var replacements = [{
     }
 }];
 
-let ignoreElements = [
+let unitsExt_ignoreElements = [
     "code",
     "pre",
     "xmp"
@@ -92,11 +92,11 @@ function replacePattern(node, patterns) {
         for(var i = 0, len = patterns.length; i < len; ++i) {
             node.nodeValue = node.nodeValue.replace(patterns[i].pattern, patterns[i].func);
         }
-    } else if(node.nodeType === Node.ELEMENT_NODE && !ignoreElements.includes(node.tagName.toLowerCase())) {
+    } else if(node.nodeType === Node.ELEMENT_NODE && !unitsExt_ignoreElements.includes(node.tagName.toLowerCase())) {
         for(var i = 0, num = node.childNodes.length; i < num; ++i) {
             replacePattern(node.childNodes[i], patterns);
         }
     }
 }
 
-replacePattern(document.body, replacements);
+replacePattern(document.body, unitsExt_Replacements);

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -3,7 +3,16 @@ function wrap(str) {
 }
 
 function convertFeetToSI(match, feet, inches, p3, offset, str){
+    // Make sure that inches are always at least 0, because sometimes 
+    // people use just 6' to denote length in feet 
+    inches = inches != null && inches.trim().length > 0 ? inches : 0
+
     var length = Math.round(100 * (parseInt(feet, 10) * 30.48 + parseInt(inches, 10) * 2.54)) / 100;
+
+    // If for some reason the length could not be computed, just leave the match alone
+    if (Number.isNaN(length)) {
+        return match
+    }
     if(length > 230) {
         return match + wrap(Math.round(length) / 100 + "m");
     } else {

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -1,5 +1,6 @@
 function wrap(str) {
-  return ' (' + str + ')';
+    return ' (' + str + ')';
+}
 }
 
 var replacements = [{

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -13,6 +13,18 @@ function convertFeetToSI(match, feet, inches, p3, offset, str){
     if (Number.isNaN(length)) {
         return match
     }
+
+    // Here we make sure that numbers at the end of sentences surrounded by '' are left alone, as
+    // they are most likely not feet. To do that, searching at the matching location backwards,
+    // we are looking for the next position of a '. If it is not between letters (e.g. "don't") 
+    // or if there is no number preceding it (e.g. "5'") then we ignore the match
+    var stringUntilMatch = str != undefined ? str.slice(0, offset) : ""
+    stringUntilMatch = stringUntilMatch.split('').reverse().join('') //Reverse the string
+
+    if (/^(?:[^0-9]+?)'\s/.test(stringUntilMatch)) {
+        return match
+    }
+
     if(length > 230) {
         return match + wrap(Math.round(length) / 100 + "m");
     } else {

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -1,31 +1,23 @@
 function wrap(str) {
     return ' (' + str + ')';
 }
+
+function convertFeetToSI(match, feet, inches, p3, offset, str){
+    var length = Math.round(100 * (parseInt(feet, 10) * 30.48 + parseInt(inches, 10) * 2.54)) / 100;
+    if(length > 230) {
+        return match + wrap(Math.round(length) / 100 + "m");
+    } else {
+        return match + wrap(length + "cm");
+    }
 }
 
 var replacements = [{
     /* Change heights in format 6'5" to metric units */
     pattern: /(\d+)'(\d*)("|''|)/g,
-    func: function(match, feet, inches, p3, offset, str){
-        var length = Math.round(100 * (parseInt(feet, 10) * 30.48 + parseInt(inches, 10) * 2.54)) / 100;
-
-        if(length > 230) {
-            return match + wrap(Math.round(length) / 100 + "m");
-        } else {
-            return match + wrap(length + "cm");
-        }
-    }
+    func: convertFeetToSI
 },{
     pattern: /(\d+)ft ?(\d*)in/g,
-    func: function(match, feet, inches, p3, offset, str){
-        var length = Math.round(100 * (parseInt(feet, 10) * 30.48 + parseInt(inches, 10) * 2.54)) / 100;
-
-        if(length > 230) {
-            return match + wrap(Math.round(length) / 100 + "m");
-        } else {
-            return match + wrap(length + "cm");
-        }
-    }
+    func: convertFeetToSI
 },{
     pattern: /(\d+\.?\d*) ?pounds?/ig,
     func: function(match, lbs, offset, str){

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -67,12 +67,18 @@ var replacements = [{
     }
 }];
 
+let ignoreElements = [
+    "code",
+    "pre",
+    "xmp"
+]
+
 function replacePattern(node, patterns) {
     if(node.nodeType === Node.TEXT_NODE) {
         for(var i = 0, len = patterns.length; i < len; ++i) {
             node.nodeValue = node.nodeValue.replace(patterns[i].pattern, patterns[i].func);
         }
-    } else if(node.nodeType === Node.ELEMENT_NODE) {
+    } else if(node.nodeType === Node.ELEMENT_NODE && !ignoreElements.includes(node.tagName.toLowerCase())) {
         for(var i = 0, num = node.childNodes.length; i < num; ++i) {
             replacePattern(node.childNodes[i], patterns);
         }


### PR DESCRIPTION
Hi,

I've been using your extension for a while, however, I've never liked that it also edits code blocks or numbers in strings. Often you find code like `var x = '5'` on a website, which this extension would transform to `var x = '5' (NaNcm)` - which of course means you can't just copy and paste code anymore.  

I've changed the code so that 

1. If the conversion results in NaN, the source text is left unchanged
2. As is often the case online, if someone uses <number>' to denote feet, the extension will now work correctly (e.g. "This is a 6' plywood piece") 
3. In general, text that is delimited by `'` will be left unchanged (e.g. "'My mother was 12', she said.") 

I've whipped up a couple tests to showcase this, which you can compare here: 

Before:
-------

<img width="535" alt="screenshot 2017-03-16 14 42 00" src="https://cloud.githubusercontent.com/assets/279407/24019795/c411add8-0a56-11e7-8a58-24a8e95ae341.png">

After:
-------

<img width="494" alt="screenshot 2017-03-16 14 41 30" src="https://cloud.githubusercontent.com/assets/279407/24019802/cabcc208-0a56-11e7-80dc-4a69db5725b1.png">

