### PR TITLE
Correctly ignore decades (e.g. 80’s)

### DIFF
--- a/test.html
+++ b/test.html
@@ -52,6 +52,7 @@
         <p>This is some text with a 'string 6'</p>
         <p>This is some text with a 'much longer string that also includes 6'</p>
         <p>This is some text that shouldn't be ignored 6'</p>
+        <p>My dad was born in the 1970's (should be ignored)</p>
 
         <h3>Date and Time</h3>
         <p>1/21/16 1pm</p>

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -50,7 +50,7 @@ function zeroPad(number, length) {
 
 var unitsExt_Replacements = [{
     /* Change heights in format 6'5" to metric units */
-    pattern: /(\d+)'(\d*)("|''|)/g,
+    pattern: /(\d+)'(?:(\d+)("|'')|(?=[\s,\.]))/g,
     func: convertFeetToSI
 },{
     pattern: /(\d+)ft ?(\d*)in/g,


### PR DESCRIPTION
This is a minor fix to ignore decades in text. Previously stuff like 1970's or 80's was matched and interpreted as height, which shouldn't happen anymore with the updated regex. 

This was caused by the empty match at the end of the previous regex and because the second number was also optional. The number and `"` sign are now grouped together, or the match is discarded if there is anything other than whitespace or punctuation after the match. 