### PR TITLE
Remove m/n suffix from time conversion

### DIFF
--- a/test.html
+++ b/test.html
@@ -59,7 +59,7 @@
         <p>01/21/16 1:00 AM</p>
         <p>01/21/2016 12:00a.m.</p>
         <p>04/03/54 12:00 PM</p>
-        <p>12:00M 12:00N 12/12/12 12:00 midnight 12:00 noon</p>
+        <p>12/12/12 12:00 midnight 12 noon</p>
         <p>13/12/21 (should not change)</p>
         <p>15:00 (should not change)</p>
 

--- a/units.safariextension/units.js
+++ b/units.safariextension/units.js
@@ -97,7 +97,7 @@ var unitsExt_Replacements = [{
     }
 },{
     /* 12 hour time to 24 hours */
-    pattern: /(\d{1,2}):?(\d{0,2})\s*(?:(p|a)\.?m\.?|(midnight|noon|[mn]\b))/ig,
+    pattern: /(\d{1,2}):?(\d{0,2})\s*(p|a)\.?m\.?|12\:?0?0?\s*(midnight|noon)/ig,
     func: function(match, h, m, meridiem, noon, offset, str){
         var hours = parseInt(h)
         var minutes = parseInt(m) || 0
@@ -109,9 +109,9 @@ var unitsExt_Replacements = [{
                 hours = 0
             }
         } else if (noon != undefined) {
-            if(noon.toLowerCase().startsWith("n") && hours == 12) {
+            if(noon.toLowerCase() == "noon") {
                 hours = 12
-            } else if(noon.toLowerCase().startsWith("m") && hours == 12) {
+            } else if(noon.toLowerCase() == "midnight") {
                 hours = 0
             }
         }


### PR DESCRIPTION
That was a stupid idea, it often picked up random numbers, e.g. people's ages. The refactored regex should be more robust in only picking up actual times. 